### PR TITLE
Remove sudo from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ echo 'Installing consave...'
 
 # Copy 'consave' to ~/.local/bin/
 cp ./consave ~/.local/bin
-sudo chmod +x ~/.local/bin/consave
+chmod +x ~/.local/bin/consave
 
 # Done
 echo 'Installed successfully! You can now delete this folder.'


### PR DESCRIPTION
Root privileges are not required to change the executable flag of files in the user's directory. Also, not all people have sudo installed.